### PR TITLE
Event page implemented, with dummy data, calender source from Google calender

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,3 +76,6 @@ gem 'jquery-ui-rails'
 #for super admin
 gem 'activeadmin', github: 'gregbell/active_admin'
 gem 'kaminari'
+
+#events
+gem 'fullcalendar-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ GEM
       xml-magic
     formtastic (2.3.0.rc3)
       actionpack (>= 3.0)
+    fullcalendar-rails (1.6.4.0)
     haml (4.0.5)
       tilt
     haml-rails (0.5.3)
@@ -196,6 +197,7 @@ DEPENDENCIES
   bootstrap-sass
   coffee-rails (~> 4.0.0)
   flickr_fu
+  fullcalendar-rails
   haml
   haml-rails
   jbuilder (~> 1.2)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,3 +20,6 @@
 //= require ./plugins/bootstrapValidator
 //= require ./post
 //= require ./register
+//= require fullcalendar
+//= require gcal
+//= require ./events

--- a/app/assets/javascripts/events.js.coffee
+++ b/app/assets/javascripts/events.js.coffee
@@ -1,0 +1,2 @@
+$ ->
+  $("#calendar").fullCalendar events: "https://www.google.com/calendar/feeds/m0d17oakiq039ptgjk7pd3uvdc%40group.calendar.google.com/public/basic"

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -11,6 +11,7 @@
  *= require jquery.ui.autocomplete
  *= require_self
  *= require carousel
+ *= require fullcalendar
  *= require_tree ./plugins
  */
 

--- a/app/controllers/post_controller.rb
+++ b/app/controllers/post_controller.rb
@@ -19,6 +19,9 @@ class PostController < ApplicationController
     end
   end
 
+  def events
+  end
+
   private
   def contact_params
     params.require(:contact).permit(:name, :contact_email, :mobile, :message)

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -27,6 +27,7 @@
                 %li= link_to "About", about_path
                 %li= link_to "Contact Us", new_contact_path
                 %li= link_to "Register for Camp", new_user_path
+                %li= link_to "Events", events_path
     = yield
   %footer
     %hr

--- a/app/views/post/events.html.haml
+++ b/app/views/post/events.html.haml
@@ -1,0 +1,2 @@
+.container.pull-down
+  #calendar

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ FsmkCampWebsite::Application.routes.draw do
   get '/technologies' => 'post#technologies'
   get '/sponsors' => 'post#sponsors'
   get '/gallery' => 'post#gallery'
+  get '/events' => 'post#events'
   
   root 'post#index'
   # Example of regular route:


### PR DESCRIPTION
Event page implemented
With Google calendar dummy data.

Note: <b>bundle install</b>

Follow below steps and create a Google calender and events to that date and time. And update the URL in <b>events.js.coffee</b>

<b>You must first make your Google Calendar public:</b>

In the Google Calendar interface, locate the "My Calendar" box on the left.
Click the arrow next to the calendar you need.
A menu will appear. Click "Share this calendar."
Check "Make this calendar public."
Make sure "Share only my free/busy information" is unchecked.
Click "Save."

<b>Then, you must obtain your calendar's XML feed URL:</b>

In the Google Calendar interface, locate the "My Calendar" box on the left
Click the arrow next to the calendar you need.
A menu will appear. Click "Calendar settings."
In the "Calendar Address" section of the screen, click the XML badge.
Your feed's URL will appear.
